### PR TITLE
Csrf support

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 APP_ID=express-microservice
 PORT=3000
-LOG_LEVEL=debug
+LOG_LEVEL=info
 REQUEST_LIMIT=100kb
 SESSION_SECRET=mySecret
 TIME_OUT=7000

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ npm run dash
 * This will start up the application with the node dashboard attached providing details of the memory , cpu and logs
 
 #### CSRF Security
-* CSRF Security has been enabled in the production build
+* CSRF Security has been enabled in the **production** mode
 * All POST APIs will require to read the cookie 'XSRF-TOKEN' set in the browser and then pass it in the response head with either of the following keys
 ** req.headers['csrf-token'] - the CSRF-Token HTTP request header.
 ** req.headers['xsrf-token'] - the XSRF-Token HTTP request header.

--- a/README.md
+++ b/README.md
@@ -201,6 +201,14 @@ npm run dash
 ```
 * This will start up the application with the node dashboard attached providing details of the memory , cpu and logs
 
+#### CSRF Security
+* CSRF Security has been enabled in the production build
+* All POST APIs will require to read the cookie 'XSRF-TOKEN' set in the browser and then pass it in the response head with either of the following keys
+** req.headers['csrf-token'] - the CSRF-Token HTTP request header.
+** req.headers['xsrf-token'] - the XSRF-Token HTTP request header.
+** req.headers['x-csrf-token'] - the X-CSRF-Token HTTP request header.
+** req.headers['x-xsrf-token'] - the X-XSRF-Token HTTP request header.
+
 ### Try It
 
 * Point you're browser to [http://localhost:3000](http://localhost:3000)

--- a/server/api/controllers/examples/controller.ts
+++ b/server/api/controllers/examples/controller.ts
@@ -102,7 +102,7 @@ export class Controller {
     ExamplesService
       .create(req.body.name)
       .then(r => {
-        res.status(HttpStatus.CREATED).location(`/api/v1/examples/${r.id}`).end();
+        res.status(HttpStatus.CREATED).location(`/api/v1/examples/${r.id}`).json(r).end();
         LogManager.getInstance().logAPITrace(req, res, HttpStatus.CREATED);
         AppMetrics.getInstance().logAPIMetrics(req, res, HttpStatus.CREATED);
       }

--- a/server/common/swagger/Api.yaml
+++ b/server/common/swagger/Api.yaml
@@ -36,6 +36,10 @@ paths:
       tags:
         - Examples
       description: Create a new example
+      consumes:
+      - application/json
+      produces:
+      - application/json
       parameters:
         - name: body
           in: body
@@ -44,8 +48,10 @@ paths:
           schema: 
             $ref: "#/definitions/ExampleBody"
       responses:
-        200:
-          description: Returns all examples
+        201:
+          description: Example posted
+        403:
+          description: Forbidden Request
 
   /examples/{id}:
     get:


### PR DESCRIPTION
CSRF Security added . This was been enabled in the production mode for now , so that the swagger apis can be tested without CSRF enabled during development.